### PR TITLE
Fix the dependency build issue, and the incorrect math

### DIFF
--- a/ALTTPRCropDashboard.sln
+++ b/ALTTPRCropDashboard.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "ALTTPRCropDashboard", "ALTTPRCropDashboard.vbproj", "{3061E7AB-43E7-47EC-A045-3F8DD17B6595}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3061E7AB-43E7-47EC-A045-3F8DD17B6595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3061E7AB-43E7-47EC-A045-3F8DD17B6595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3061E7AB-43E7-47EC-A045-3F8DD17B6595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3061E7AB-43E7-47EC-A045-3F8DD17B6595}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7D97EC9A-39A0-4674-AB3C-3A98211DC4E0}
+	EndGlobalSection
+EndGlobal

--- a/ALTTPRCropDashboard.vbproj
+++ b/ALTTPRCropDashboard.vbproj
@@ -49,11 +49,10 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\OBS.WebSocketInterface.3.0.0\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="obs-websocket-dotnet, Version=4.2.0.3, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\DLL\obs-websocket-dotnet.dll</HintPath>
+      <HintPath>packages\obs-websocket-dotnet.4.2.0-beta3\lib\net40\obs-websocket-dotnet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -65,8 +64,8 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="websocket-sharp.clone, Version=1.0.2.39869, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\websocket-sharp.clone.3.0.0\lib\net45\websocket-sharp.clone.dll</HintPath>
+    <Reference Include="websocket-sharp, Version=1.0.2.59611, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
+      <HintPath>packages\WebSocketSharp.1.0.3-rc11\lib\websocket-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ALTTPRCropDashboard.vbproj
+++ b/ALTTPRCropDashboard.vbproj
@@ -82,6 +82,7 @@
     <Import Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CropperMath.vb" />
     <Compile Include="IniParser.vb" />
     <Compile Include="MathCalcs.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />

--- a/CropperMath.vb
+++ b/CropperMath.vb
@@ -1,0 +1,73 @@
+﻿Public Class CropperMath
+
+    Public Property DefaultCrop As New Rectangle
+
+
+    Public Function RemoveDefaultCrop(rect As Rectangle) As Rectangle
+        Return Rectangle.FromLTRB(Math.Max(rect.Left - DefaultCrop.Left, 0),
+                                  Math.Max(rect.Top - DefaultCrop.Top, 0),
+                                  Math.Max(rect.Right - DefaultCrop.Right, 0),
+                                  Math.Max(rect.Bottom - DefaultCrop.Bottom, 0)
+                                )
+    End Function
+
+    Public Function RemoveDefaultCropSize(size As Size) As Size
+        Return New Size(Math.Max(size.Width - DefaultCrop.Left - DefaultCrop.Right, 0),
+                        Math.Max(size.Height - DefaultCrop.Top - DefaultCrop.Bottom, 0))
+    End Function
+
+    Public Function AddDefaultCrop(rect As Rectangle) As Rectangle
+        Return Rectangle.FromLTRB(rect.Left + DefaultCrop.Left, rect.Top + DefaultCrop.Top, rect.Right + DefaultCrop.Right, rect.Bottom + DefaultCrop.Bottom)
+    End Function
+
+
+    Public Function AddDefaultCropSize(size As Size) As Size
+        Return New Size(size.Width + DefaultCrop.Left + DefaultCrop.Right,
+                        size.Height + DefaultCrop.Top + DefaultCrop.Bottom)
+    End Function
+
+    Public Function AdjustCrop(crop As CropInfo, newMasterSizeWithoutDefault As Size) As CropInfo
+        'Let's calculate how much we differ from the original source
+        Dim aspectRatioScale As New PointF(newMasterSizeWithoutDefault.Width / crop.MasterSizeWithoutDefault.Width, newMasterSizeWithoutDefault.Height / crop.MasterSizeWithoutDefault.Height)
+        'From that, we take the smaller ratio
+        Dim aspectRatioChange = Math.Min(aspectRatioScale.X, aspectRatioScale.Y)
+        'Then by scaling the original, we get the size of the video when scaled up.
+        Dim scaledMasterSize As New Size(crop.MasterSizeWithoutDefault.Width * aspectRatioChange,
+                                         crop.MasterSizeWithoutDefault.Height * aspectRatioChange)
+        'And the remaining space is black bars.
+        Dim blackBarsSize As New Size(newMasterSizeWithoutDefault.Width - scaledMasterSize.Width,
+                                      newMasterSizeWithoutDefault.Height - scaledMasterSize.Height)
+        'These black bars are around the source. On non-even sizes, 1px bigger on one side.
+        Dim blackBars = Rectangle.FromLTRB(Math.Ceiling(blackBarsSize.Width / 2.0),
+                                           Math.Ceiling(blackBarsSize.Height / 2.0),
+                                           Math.Floor(blackBarsSize.Width / 2.0),
+                                           Math.Floor(blackBarsSize.Height / 2.0))
+        'Now we also scale the crop numbers, since they now refer to a much bigger stream.
+        Dim scaledCrop = Rectangle.FromLTRB(crop.CropWithoutDefault.Left * aspectRatioChange,
+                                            crop.CropWithoutDefault.Top * aspectRatioChange,
+                                            crop.CropWithoutDefault.Right * aspectRatioChange,
+                                            crop.CropWithoutDefault.Bottom * aspectRatioChange)
+
+
+        Return New CropInfo With {
+                .CropWithoutDefault = scaledCrop,
+                .BlackBars = blackBars,
+                .MasterSizeWithoutDefault = scaledMasterSize
+            }
+
+    End Function
+
+End Class
+
+
+Public Class CropInfo
+    Public Property CropWithoutDefault As Rectangle
+    Public Property BlackBars As New Rectangle
+    Public Property MasterSizeWithoutDefault As Size
+
+    Public ReadOnly Property CropWithBlackBarsWithoutDefault As Rectangle
+        Get
+            Return Rectangle.FromLTRB(CropWithoutDefault.Left + BlackBars.Left, CropWithoutDefault.Top + BlackBars.Top, CropWithoutDefault.Right + BlackBars.Right, CropWithoutDefault.Bottom + BlackBars.Bottom)
+        End Get
+    End Property
+End Class

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="OBS.WebSocketInterface" version="3.0.0" targetFramework="net461" />
-  <package id="websocket-sharp.clone" version="3.0.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="obs-websocket-dotnet" version="4.2.0-beta3" targetFramework="net461" />
+  <package id="WebSocketSharp" version="1.0.3-rc11" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This PR changes the nuget packages used by the project, to depend on the right obs-websocket-dotnet, causing it to compile directly from pull.

It also brings corrected and cleaned up math. This math works every time for what I tested.