### PR TITLE
Squirrel installer, part 2

### DIFF
--- a/OBSWebSocketCropper.vb
+++ b/OBSWebSocketCropper.vb
@@ -786,11 +786,6 @@ Public Class ObsWebSocketCropper
     Private Sub OBSWebScocketCropper_Load(sender As Object, e As EventArgs) Handles Me.Load
 
 
-        If My.Settings.UpgradeRequired = True Then
-            My.Settings.Upgrade()
-            My.Settings.UpgradeRequired = False
-            My.Settings.Save()
-        End If
 
         ReuseInfo = True
 

--- a/OBSWebSocketCropper.vb
+++ b/OBSWebSocketCropper.vb
@@ -13,8 +13,16 @@ Public Class ObsWebSocketCropper
     Public ObsConnectionStatus2 As String
 
     Private WithEvents _obs2 As New ObsWebSocketPlus
-    Public ConnectionString As String
-    Public ConnectionString2 As String
+    Public ReadOnly Property ConnectionString As String
+        Get
+            Return My.Settings.ConnectionString1 & ":" & My.Settings.ConnectionPort1
+        End Get
+    End Property
+    Public ReadOnly Property ConnectionString2 As String
+        Get
+            Return My.Settings.ConnectionString2 & ":" & My.Settings.ConnectionPort2
+        End Get
+    End Property
 
     Public Shared ObsSettingsResult As String
     Public Shared NewRunnerName As String
@@ -522,6 +530,9 @@ Public Class ObsWebSocketCropper
     Private Sub RefreshVlc()
 
         Dim vlcProcesses = Process.GetProcesses().Where(Function(pr) pr.ProcessName.StartsWith("vlc", True, Globalization.CultureInfo.InvariantCulture)).ToList()
+        If Not vlcProcesses.Any() Then
+            Exit Sub
+        End If
 
         Dim leftVlc, rightVlc As String
 
@@ -786,14 +797,9 @@ Public Class ObsWebSocketCropper
     Private Sub OBSWebScocketCropper_Load(sender As Object, e As EventArgs) Handles Me.Load
 
 
-
         ReuseInfo = True
-
-        ConnectionString = My.Settings.ConnectionString1 & ":" & My.Settings.ConnectionPort1
-
         lblOBS1ConnectedStatus.Text = "Not Connected"
         lblOBS2ConnectedStatus.Text = "Not Connected"
-
         ConfigureDataBindings()
         CreateNewSourceTable()
 
@@ -1022,7 +1028,6 @@ Public Class ObsWebSocketCropper
         Cursor = Cursors.WaitCursor
 
         Try
-            ConnectionString2 = My.Settings.ConnectionString2 & ":" & My.Settings.ConnectionPort2
 
             If Not _obs2.IsConnected Then
 
@@ -1045,7 +1050,6 @@ Public Class ObsWebSocketCropper
     Public Sub ConnectToObs()
         Cursor = Cursors.WaitCursor
         Try
-            ConnectionString = My.Settings.ConnectionString1 & ":" & My.Settings.ConnectionPort1
 
             If Obs.IsConnected = False Then
                 Dim isPortOpen As Boolean = Obs.IsPortOpen(ConnectionString)

--- a/Program.vb
+++ b/Program.vb
@@ -20,6 +20,12 @@ Public Module Program
     End Sub
 
     Public Sub Main()
+        If My.Settings.UpgradeRequired = True Then
+            My.Settings.Upgrade()
+            My.Settings.UpgradeRequired = False
+            My.Settings.Save()
+        End If
+
         Using updateMgr = New UpdateManager(If(ConfigurationManager.AppSettings("ReleasesURL"), "C:\TestReleases"))
 
             ' ReSharper disable AccessToDisposedClosure

--- a/Program.vb
+++ b/Program.vb
@@ -1,5 +1,6 @@
 ﻿Imports System.Configuration
 Imports System.IO
+Imports System.Linq
 Imports Squirrel
 
 Public Module Program
@@ -12,13 +13,14 @@ Public Module Program
                  End Function)
     End Sub
     Private Sub CreateShortcuts(mgr As UpdateManager)
-        Dim path = System.IO.Path.Combine(Application.StartupPath, $"app-{mgr.CurrentlyInstalledVersion()}", "dashboard.exe")
-        mgr.CreateShortcutsForExecutable(path, ShortcutLocation.Desktop Or ShortcutLocation.StartMenu, False)
+        Dim thePath = Path.Combine(Path.GetDirectoryName(Application.StartupPath), $"app-{mgr.CurrentlyInstalledVersion()}", "dashboard.exe")
+        mgr.CreateShortcutsForExecutable(thePath, ShortcutLocation.Desktop Or ShortcutLocation.StartMenu, False)
 
         mgr.CreateShortcutForThisExe()
     End Sub
     Private Sub DeleteShortcuts(mgr As UpdateManager)
-        mgr.RemoveShortcutsForExecutable("dashboard.exe", ShortcutLocation.Desktop Or ShortcutLocation.StartMenu)
+        Dim thePath = Path.Combine(Path.GetDirectoryName(Application.StartupPath), $"app-{mgr.CurrentlyInstalledVersion()}", "dashboard.exe")
+        mgr.RemoveShortcutsForExecutable(thePath, ShortcutLocation.Desktop Or ShortcutLocation.StartMenu)
         mgr.RemoveShortcutForThisExe()
     End Sub
 
@@ -34,7 +36,7 @@ Public Module Program
         Dim updatePath = If(ConfigurationManager.AppSettings("ReleasesURL"), testFolder)
 
         If (updatePath <> testFolder OrElse System.IO.Directory.Exists(testFolder)) AndAlso
-            File.Exists(Path.Combine(Application.StartupPath, "Update.exe")) Then
+            File.Exists(Path.Combine(Path.GetDirectoryName(Application.StartupPath), "Update.exe")) Then
             Using updateMgr = New UpdateManager(If(ConfigurationManager.AppSettings("ReleasesURL"), "C:\TestReleases"))
 
                 ' ReSharper disable AccessToDisposedClosure


### PR DESCRIPTION
This also fixes a bunch of bugs with the initial configuration state that were found while testing.

This also re-enables debugging when it's not in an installed state.

This built version was used in "combined" version 1.2 available to genpop.